### PR TITLE
Fix USB OTG

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-ccimx6sbc.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-ccimx6sbc.dtsi
@@ -911,7 +911,7 @@
 &usbotg {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_usbotg>;
-	digi,power-line-active-high;
+	power-active-high;
 };
 
 &usdhc2 {


### PR DESCRIPTION
It seems that the driver drivers/usb/chipidea/ci_hdrc_imx.c has changed at some point and it expects the property `power-active-high` instead of the old `digi,power-line-active-high`. That's why the VBUS is at 5V when working as a peripheral and 0V when working as a host.