### PR TITLE
Enable CS1 for ccimx8x-sbc-pro to conform to the documentation

### DIFF
--- a/arch/arm64/boot/dts/digi/ccimx8x-sbc-pro.dts
+++ b/arch/arm64/boot/dts/digi/ccimx8x-sbc-pro.dts
@@ -282,12 +282,11 @@
 		spi-max-frequency = <4000000>;
 	};
 
-/*  Uncomment to add a second SPI slave device controlled by CS 1 */
-//	spidev@1 {
-//		compatible = "spidev";
-//		reg = <1>;
-//		spi-max-frequency = <4000000>;
-//	};
+	spidev@1 {
+		compatible = "spidev";
+		reg = <1>;
+		spi-max-frequency = <4000000>;
+	};
 };
 
 /* LPUART0 on expansion header */


### PR DESCRIPTION
It is stated in [the documentation](https://www.digi.com/resources/documentation/digidocs/embedded/dey/3.2/cc8x/bsp_r_spi_8x.html) that CS0 and CS1 are enabled, however, this is not the case for the gatesgarth image.